### PR TITLE
Add an init command. Closes #19.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,17 @@ cargo install hoi
 
 ### Configuration
 
-Create a `.hoi.yml` file in your project directory with the following structure:
+You can create a new `.hoi.yml` file using the built-in init command:
+
+```bash
+hoi init
+```
+
+This will create a template `.hoi.yml` file in your current directory with some
+example commands to get you started.
+
+Alternatively, you can manually create a `.hoi.yml` file in your project
+directory with the following structure:
 
 ```yaml
 version: 1
@@ -80,7 +90,7 @@ hoi
 Execute a specific command:
 
 ```bash
-hoi command|alias [additional args]
+hoi [command|alias] (command options) (command arguments...)
 ```
 
 Hoi can also call itself, allowing you to chain different commands together 

--- a/src/hoi.rs
+++ b/src/hoi.rs
@@ -12,8 +12,6 @@ pub enum HoiError {
     YamlParsing(#[from] serde_yaml::Error),
     #[error("Command not found: {0}")]
     CommandNotFound(String),
-    #[error("No .hoi.yml file found in current directory or parent directories, and no global config was found at ~/.hoi/.hoi.global.yml.")]
-    ConfigNotFound,
     #[error("No commands defined in .hoi.yml file. You need at least one command defined.")]
     NoCommandsDefined,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,7 +142,11 @@ fn display_commands(hoi: &Hoi) {
     builder.push_record(["Command", "Alias", "Description"]);
 
     // Add built-in commands
-    builder.push_record(["init", "", "Create a new .hoi.yml configuration file in the current directory."]);
+    builder.push_record([
+        "init",
+        "",
+        "Create a new .hoi.yml configuration file in the current directory.",
+    ]);
 
     // Add rows for each command
     for (name, command) in &hoi.commands {
@@ -164,8 +168,7 @@ fn display_commands(hoi: &Hoi) {
 
     if !hoi.description.is_empty() {
         println!("\n{}\n", hoi.description);
-    }
-    else {
+    } else {
         println!();
     }
 
@@ -263,7 +266,10 @@ fn create_init_config() -> Result<(), Box<dyn std::error::Error>> {
     let config_path = current_dir.join(".hoi.yml");
 
     if config_path.exists() {
-        println!("A .hoi.yml file already exists at {}", config_path.display());
+        println!(
+            "A .hoi.yml file already exists at {}",
+            config_path.display()
+        );
         return Ok(());
     }
 
@@ -313,12 +319,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Parse command line arguments early to check for 'init' command
     let mut args: Vec<String> = env::args().skip(1).collect();
-    
+
     // Handle the 'init' command before looking for config files
     if !args.is_empty() && args[0] == "init" {
         return create_init_config();
     }
-    
+
     // Find and load the local config file (project-specific)
     let local_config_path = find_config_file();
 
@@ -528,33 +534,44 @@ mod tests {
         assert!(result.is_some(), "Failed to find global config file");
         assert_eq!(result.unwrap(), global_config_path);
     }
-    
+
     #[test]
     fn test_init_command() {
         let temp_dir = tempdir().unwrap();
         env::set_current_dir(temp_dir.path()).unwrap();
-        
+
         // Run the init config function
         let result = create_init_config();
-        assert!(result.is_ok(), "Failed to create init config: {:?}", result.err());
-        
+        assert!(
+            result.is_ok(),
+            "Failed to create init config: {:?}",
+            result.err()
+        );
+
         // Verify the config file was created
         let config_path = temp_dir.path().join(".hoi.yml");
         assert!(config_path.exists(), "Config file was not created");
-        
+
         // Test that running init again when file exists doesn't overwrite it
         let original_content = fs::read_to_string(&config_path).unwrap();
-        
+
         // Modify the file slightly to detect if it gets overwritten
         let modified_content = original_content.replace("Custom commands", "Test commands");
         fs::write(&config_path, modified_content).unwrap();
-        
+
         // Run init again
         let result = create_init_config();
-        assert!(result.is_ok(), "Failed on second init run: {:?}", result.err());
-        
+        assert!(
+            result.is_ok(),
+            "Failed on second init run: {:?}",
+            result.err()
+        );
+
         // Verify content wasn't overwritten
         let final_content = fs::read_to_string(&config_path).unwrap();
-        assert!(final_content.contains("Test commands"), "Config file was incorrectly overwritten");
+        assert!(
+            final_content.contains("Test commands"),
+            "Config file was incorrectly overwritten"
+        );
     }
 }


### PR DESCRIPTION
Add a default 'init' command that is always available. Remove the early return Errors in main() to allow program to run without configuration present so this new command is always available.